### PR TITLE
fix: Docker Health-Checks auf curl-freie Alternativen umstellen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 
 # Serena
 .serena/
+
+# PindeX index data
+.pindex/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,3 +283,25 @@ Detaillierte Anforderungen und Prompts liegen unter `planung/`:
 | `11-rueckfrage-system.md` | Interaktiver KI-Dialog bei unklaren Dokumenten |
 
 Die Prompts sind sequenziell zu verwenden. Jeder Prompt hat Akzeptanzkriterien die erfuellt sein muessen bevor der naechste begonnen wird.
+
+## PindeX – Codebase Navigation
+
+Dieses Projekt ist mit PindeX indexiert.
+
+**PFLICHT-WORKFLOW** – bei jeder Codebase-Aufgabe:
+1. **Unbekannte Datei?** → `mcp__pindex__get_file_summary` ZUERST, dann ggf. `get_context`
+2. **Symbol suchen?** → `mcp__pindex__search_symbols` oder `find_symbol`
+3. **Abhängigkeiten?** → `mcp__pindex__get_dependencies`
+4. **Wo wird etwas verwendet?** → `mcp__pindex__find_usages`
+5. **Projekt-Überblick?** → `mcp__pindex__get_project_overview`
+
+**VERBOTEN** (solange PindeX verfügbar):
+- `Read` auf Quellcode-Dateien ohne vorherigen `get_file_summary`-Aufruf
+- `Glob`/`Grep` zur Symbol-Suche statt `search_symbols`
+
+**Kontext auslagern:**
+- Wichtige Entscheidungen / Muster → `mcp__pindex__save_context` speichern
+- Zu Sessionbeginn → `mcp__pindex__search_docs` für gespeicherten Kontext
+
+**Fallback:** Falls ein Tool `null` zurückgibt → `Read`/`Grep` als Fallback.
+<!-- pindex -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -26,9 +26,9 @@ services:
       - ollama-models:/root/.ollama
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD", "ollama", "list"]
       interval: 30s
-      timeout: 5s
+      timeout: 10s
       retries: 3
       start_period: 10s
 
@@ -38,7 +38,7 @@ services:
       - chromadb-data:/chroma/chroma
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v2/heartbeat"]
+      test: ["CMD-SHELL", "grep -q '00000000:1F40' /proc/net/tcp"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- **Backend:** Health-Check von `curl` auf `python urllib.request` umgestellt (curl nicht im Image)
- **Ollama:** Health-Check auf `ollama list` CLI umgestellt
- **ChromaDB:** Health-Check auf `/proc/net/tcp` Port-Prüfung umgestellt (kein curl/wget/python im Image)
- **ChromaDB:** Service wurde nicht gestartet und musste manuell hochgefahren werden

## Hintergrund

Alle drei Health-Checks verwendeten `curl`, das in keinem der Container installiert ist. Das führte zu dauerhaft `unhealthy`-Status und verhinderte bei Neustarts den korrekten Startup (Backend wartet auf `service_healthy` von ChromaDB).

## Test plan

- [ ] `docker compose up -d` startet alle vier Container
- [ ] `docker compose ps` zeigt alle Services als `healthy`
- [ ] Frontend unter http://localhost:8080 erreichbar
- [ ] RAG-Chat funktioniert (ChromaDB erreichbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)