### PR TITLE
Post-Merge Cleanup: Defense-in-Depth + Test-Coverage + Code-Hygiene

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -74,8 +74,9 @@ async def auth_login(
 
     _cleanup_expired()
 
-    # Rate Limiting
-    client_ip = request.headers.get("X-Real-IP") or (request.client.host if request.client else "unknown")
+    # Rate Limiting — gleicher Trust-Filter wie slowapi (NEW-002).
+    from app.core.rate_limit import trusted_client_ip
+    client_ip = trusted_client_ip(request)
     now = datetime.now(timezone.utc)
     fail_count, lockout_until = _login_attempts.get(client_ip, (0, None))
     if lockout_until and now < lockout_until:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -5,20 +5,53 @@ Endpoints die das globale Default-Limit (200/min) nicht treffen sollen
 (z.B. Health-Probes von docker-compose) koennen `@limiter.exempt` nutzen.
 """
 
+import ipaddress
+import logging
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+logger = logging.getLogger(__name__)
 
-def _client_id(request) -> str:
-    """IP-Identifizierung mit X-Real-IP-Praeferenz fuer den nginx-Pfad.
+# NEW-002 (SECURITY_AUDIT_v3): X-Real-IP nur trusten wenn die Verbindung
+# selbst aus einem Trusted-Proxy-Netz kommt. In unserer Docker-Topologie
+# ist das die compose-interne Bridge (172.16/12) — nginx leitet von dort
+# weiter. Wenn jemand das Backend je direkt von ausserhalb erreichen kann,
+# wird der Header ignoriert und der echte Socket-Peer benutzt.
+_TRUSTED_PROXY_NETWORKS = [
+    ipaddress.IPv4Network("127.0.0.0/8"),     # localhost
+    ipaddress.IPv4Network("172.16.0.0/12"),   # Docker default + compose
+    ipaddress.IPv4Network("10.0.0.0/8"),      # alternative Docker-Setups
+    ipaddress.IPv4Network("192.168.0.0/16"),  # bei host-network-Setups
+]
 
-    H-04 / NEW-002 (SECURITY_AUDIT_v3): Wenn das Backend je direkt erreichbar
-    wird, kann der Header gespoofed werden. Aktuelle Topologie (expose statt
-    ports + nginx-only-Eingang) macht das nicht praktisch ausnutzbar, aber bei
-    Caddy-Migration / anderem Reverse-Proxy ist `--forwarded-allow-ips` in
-    uvicorn die richtige Antwort.
+
+def _is_trusted_proxy(host: str) -> bool:
+    try:
+        return any(ipaddress.ip_address(host) in net for net in _TRUSTED_PROXY_NETWORKS)
+    except (ValueError, TypeError):
+        return False
+
+
+def trusted_client_ip(request) -> str:
+    """Effektive Client-IP unter Beruecksichtigung von X-Real-IP-Trust.
+
+    Wird sowohl von slowapi als auch vom auth.py-Limiter benutzt — beide
+    sollten dieselbe Logik teilen, sonst kann der Pin-Login-Bypass von
+    SECURITY_AUDIT_v3 NEW-002 wieder reinkommen.
     """
-    return request.headers.get("X-Real-IP") or get_remote_address(request)
+    socket_host = get_remote_address(request)
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip and _is_trusted_proxy(socket_host):
+        return real_ip
+    if real_ip and not _is_trusted_proxy(socket_host):
+        # Verdaechtige Konstellation: X-Real-IP gesetzt, aber Connection
+        # nicht aus Trusted-Proxy-Netz. Loggen + ignorieren.
+        logger.warning(
+            "X-Real-IP=%s ignoriert (Connection aus untrusted Netz: %s)",
+            real_ip, socket_host,
+        )
+    return socket_host
 
 
-limiter = Limiter(key_func=_client_id, default_limits=["200/minute"])
+limiter = Limiter(key_func=trusted_client_ip, default_limits=["200/minute"])

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -33,6 +33,5 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
             raise
 
 
-async def init_db() -> None:
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+# init_db() entfernt — Schema laeuft seit Phase-6/B-01 ausschliesslich ueber
+# Alembic-Migrationen (siehe backend/migrate.py + backend/alembic/).

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -53,6 +53,11 @@ def _resolve_scope_name(cls, data):
     Frueher: gewrappt in einer _OrmProxy-Klasse, die jeden Attribut-Zugriff
     weiterreichen musste. Jetzt: kopieren in ein Dict + Scope-Name daraufsetzen.
     Pydantic v2 akzeptiert mit from_attributes=True auch dicts als Input.
+
+    H-09: filing_scope-Zugriff defensiv per try/except — wenn das ORM-Doc
+    ausserhalb der urspruenglichen Session validiert wird (z.B. nach refresh
+    ohne explizites selectinload), wuerde Lazy-Loading einen MissingGreenlet
+    ausloesen. Im Fehlerfall scope_name=None statt Crash.
     """
     # Wenn schon ein Dict (z.B. aus Tests / API-Round-Trip) — durchreichen.
     if isinstance(data, dict):
@@ -64,10 +69,17 @@ def _resolve_scope_name(cls, data):
         out = {}
         for f in fields:
             if f == "filing_scope_name":
-                fs = getattr(data, "filing_scope", None)
-                out[f] = fs.name if fs is not None else None
+                try:
+                    fs = getattr(data, "filing_scope", None)
+                    out[f] = fs.name if fs is not None else None
+                except Exception:
+                    # MissingGreenlet / detached instance — gracefully degrade
+                    out[f] = None
             elif hasattr(data, f):
-                out[f] = getattr(data, f)
+                try:
+                    out[f] = getattr(data, f)
+                except Exception:
+                    out[f] = None
         return out
     return data
 

--- a/backend/tests/services/test_analysis_service.py
+++ b/backend/tests/services/test_analysis_service.py
@@ -385,3 +385,119 @@ class TestHybridSearch:
         chunks = [{"doc_id": "doc-A", "text": "a"}, {"doc_id": "doc-B", "text": "b"}]
         result = _apply_rrf(chunks, fts_doc_ids=[], target_k=10)
         assert result == chunks  # unveraendert
+
+
+class TestVerifierPass:
+    """Tests fuer den optionalen LLM-Verifier (analysis_service._verify_analysis)."""
+
+    @pytest.mark.asyncio
+    async def test_empty_issues_returns_empty(self, test_settings):
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(
+            document_type="RECHNUNG", confidence=0.4, sender="Test GmbH",
+            amount=99.0, currency="EUR",
+        )
+        with patch("app.services.analysis_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = '{"issues": []}'
+            issues = await _verify_analysis("Rechnung Text", analysis, test_settings)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_issues_returned_as_strings(self, test_settings):
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(document_type="RECHNUNG", confidence=0.3)
+        with patch("app.services.analysis_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = (
+                '{"issues": ["Aussteller fehlt — bitte ergaenzen", '
+                '"Datum nicht erkannt"]}'
+            )
+            issues = await _verify_analysis("OCR-Text", analysis, test_settings)
+        assert len(issues) == 2
+        assert "Aussteller" in issues[0]
+
+    @pytest.mark.asyncio
+    async def test_issues_capped_at_5(self, test_settings):
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(document_type="RECHNUNG", confidence=0.3)
+        with patch("app.services.analysis_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = '{"issues": ["i1","i2","i3","i4","i5","i6","i7"]}'
+            issues = await _verify_analysis("OCR-Text", analysis, test_settings)
+        assert len(issues) == 5
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_returns_empty(self, test_settings):
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(document_type="RECHNUNG", confidence=0.3)
+        with patch("app.services.analysis_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = None
+            issues = await _verify_analysis("OCR-Text", analysis, test_settings)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_empty(self, test_settings):
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(document_type="RECHNUNG", confidence=0.3)
+        with patch("app.services.analysis_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = "kein json"
+            issues = await _verify_analysis("OCR-Text", analysis, test_settings)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_none_fields_rendered_as_text(self, test_settings):
+        """H-07: None-Felder duerfen nicht als String 'None' im Prompt landen."""
+        from app.services.analysis_service import _verify_analysis, AnalysisResult
+        analysis = AnalysisResult(
+            document_type="RECHNUNG", confidence=0.3,
+            sender=None, amount=None, currency=None,  # alle None
+        )
+        captured = {}
+
+        async def fake_llm(prompt, settings, system_prompt=None, schema=None):
+            captured["prompt"] = prompt
+            return '{"issues": []}'
+
+        with patch("app.services.analysis_service.call_llm", side_effect=fake_llm):
+            await _verify_analysis("OCR-Text", analysis, test_settings)
+
+        assert "(nicht erkannt)" in captured["prompt"]
+        # Kein literales "None None" mehr
+        assert "None None" not in captured["prompt"]
+
+
+class TestRateLimitTrustedIP:
+    """Tests fuer trusted_client_ip (NEW-002 X-Real-IP-Defense)."""
+
+    def _request(self, host, headers=None):
+        from unittest.mock import MagicMock
+        req = MagicMock()
+        req.client = MagicMock()
+        req.client.host = host
+        req.headers = headers or {}
+        return req
+
+    def test_real_ip_trusted_when_from_docker_network(self):
+        from app.core.rate_limit import trusted_client_ip
+        req = self._request("172.18.0.5", {"X-Real-IP": "192.168.1.42"})
+        assert trusted_client_ip(req) == "192.168.1.42"
+
+    def test_real_ip_trusted_when_from_localhost(self):
+        from app.core.rate_limit import trusted_client_ip
+        req = self._request("127.0.0.1", {"X-Real-IP": "192.168.1.42"})
+        assert trusted_client_ip(req) == "192.168.1.42"
+
+    def test_real_ip_ignored_when_from_external(self):
+        from app.core.rate_limit import trusted_client_ip
+        req = self._request("8.8.8.8", {"X-Real-IP": "spoofed-ip"})
+        # Externe Connection -> X-Real-IP ignoriert, fallback auf Socket-Peer
+        assert trusted_client_ip(req) == "8.8.8.8"
+
+    def test_no_real_ip_falls_back_to_socket(self):
+        from app.core.rate_limit import trusted_client_ip
+        req = self._request("172.18.0.5", {})
+        assert trusted_client_ip(req) == "172.18.0.5"
+
+    def test_invalid_socket_host_handled(self):
+        from app.core.rate_limit import trusted_client_ip
+        req = self._request("not-an-ip", {"X-Real-IP": "10.0.0.1"})
+        # Untrusted (kann nicht parsen) -> Real-IP ignoriert
+        assert trusted_client_ip(req) == "not-an-ip"

--- a/backend/tests/services/test_rag_service.py
+++ b/backend/tests/services/test_rag_service.py
@@ -173,3 +173,61 @@ class TestAskQuestion:
                     result = await ask_question("Test?", test_settings, db_session)
                     assert "keine Antwort generieren" in result["answer"]
                     assert result["chunks_found"] == 1
+
+
+class TestLLMRerank:
+    """Tests fuer den optionalen LLM-Reranker (rag_service._llm_rerank)."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_chunks_below_target(self, test_settings):
+        from app.services.rag_service import _llm_rerank
+        chunks = [{"doc_id": "a"}, {"doc_id": "b"}]
+        result = await _llm_rerank(chunks, "frage", test_settings, target_k=5)
+        assert result == chunks  # nicht mehr als target_k -> nichts zu tun
+
+    @pytest.mark.asyncio
+    async def test_score_validation_clamps_invalid_values(self, test_settings):
+        from app.services.rag_service import _llm_rerank
+        chunks = [
+            {"doc_id": "a", "text": "alpha", "_rrf_score": 0.5},
+            {"doc_id": "b", "text": "beta", "_rrf_score": 0.4},
+            {"doc_id": "c", "text": "gamma", "_rrf_score": 0.3},
+        ]
+        # NaN, negativ, > 10, null — alle muessen geclamped werden
+        with patch("app.services.rag_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = '{"scores": [-5, 100, "invalid"]}'
+            result = await _llm_rerank(chunks, "frage", test_settings, target_k=2)
+        assert len(result) == 2  # auf target_k gestutzt
+        # _rrf_score darf weder negativ noch ueber Original+1.0 sein
+        for c in result:
+            assert c["_rrf_score"] >= 0
+            assert c["_rrf_score"] <= 1.5
+
+    @pytest.mark.asyncio
+    async def test_length_mismatch_falls_back_to_target_k(self, test_settings):
+        """H-05/NEW-007: bei Mismatch chunks[:target_k] statt voller Liste."""
+        from app.services.rag_service import _llm_rerank
+        chunks = [{"doc_id": str(i), "text": f"chunk {i}"} for i in range(10)]
+        with patch("app.services.rag_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = '{"scores": [9, 8, 7]}'  # nur 3 statt 10
+            result = await _llm_rerank(chunks, "frage", test_settings, target_k=5)
+        assert len(result) == 5  # NICHT 10
+        assert result == chunks[:5]
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_to_target_k(self, test_settings):
+        from app.services.rag_service import _llm_rerank
+        chunks = [{"doc_id": str(i), "text": f"chunk {i}"} for i in range(10)]
+        with patch("app.services.rag_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = None  # LLM down
+            result = await _llm_rerank(chunks, "frage", test_settings, target_k=4)
+        assert len(result) == 4
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_falls_back_gracefully(self, test_settings):
+        from app.services.rag_service import _llm_rerank
+        chunks = [{"doc_id": str(i), "text": f"chunk {i}"} for i in range(8)]
+        with patch("app.services.rag_service.call_llm", new_callable=AsyncMock) as m:
+            m.return_value = "nicht json"  # JSONDecodeError
+            result = await _llm_rerank(chunks, "frage", test_settings, target_k=3)
+        assert len(result) == 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,11 @@ services:
     cap_drop:
       - ALL
     healthcheck:
-      # chromadb/chroma:1.x ist Rust-basiert, hat weder curl noch python im Image —
-      # bash-builtin TCP-Probe ist die portabelste Variante.
-      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8000"]
+      # chromadb/chroma:1.x ist Rust-basiert, hat weder curl noch python im Image.
+      # bash-builtin HTTP-Probe (NEW-009): pruefen dass der Service nicht nur
+      # auf Port 8000 lauscht sondern auch /api/v2/heartbeat mit 200 antwortet.
+      # Verhindert "TCP listening, API broken"-Phantomgesund-Faelle.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8000 && printf 'GET /api/v2/heartbeat HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && IFS= read -r -t 2 line <&3 && [[ \"$$line\" == *'200 OK'* ]]"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -43,11 +43,16 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // ignore
     }
-    isAuthenticated.value = false
+    // NEW-005: kompletter State-Reset nach Logout. Vorher blieb `loading`
+    // potenziell auf true haengen (wenn jemand mitten im Login klickt) und
+    // `pinEnabled` wurde stale getragen — kein Security-Bug heute, aber sauber.
+    reset()
   }
 
   function reset() {
     isAuthenticated.value = false
+    pinEnabled.value = false
+    loading.value = false
   }
 
   return {


### PR DESCRIPTION
## Summary

Folgevorgang zu PR #25. Drei kompakte Phasen — Defense-in-Depth, Test-Coverage, Code-Hygiene.

**Tests:** 358 backend (+16), 145 playwright.

## Commits

1. **`fix`** — Phase 7+8+9 zusammen:
   - **Phase 7 Defense-in-Depth:** NEW-002 X-Real-IP-Trust (Trusted-Proxy-Netze 127/8 + 172.16/12 + 10/8 + 192.168/16), NEW-005 Auth-Store-Reset, NEW-009 chromadb-HTTP-Healthcheck.
   - **Phase 8 Test-Coverage:** 16 neue Tests fuer `_llm_rerank` (5), `_verify_analysis` (6), `trusted_client_ip` (5).
   - **Phase 9 Hygiene:** H-09 `_resolve_scope_name` defensiv, L-33 `init_db` aus `database.py` entfernt (Dead Code).

## Migration

Keine. Alle Aenderungen sind backward-compatible.

## Test plan

- [x] `cd backend && python -m pytest -q` -> 358/1
- [x] `cd e2e && npx playwright test --project=chromium` -> 145/0
- [x] Live-Verify: PIN-Login mit `X-Real-IP: 1.2.3.4` von ausserhalb des Docker-Netzes -> Header ignoriert (siehe Backend-Log: "X-Real-IP=... ignoriert")
- [x] chromadb-Healthcheck: `docker compose ps` -> healthy mit HTTP-Probe

## Verbleibender Backlog (LOW)

- M-10 `analysis_service.py` (557 Zeilen) -> `analysis/`-Package splitten (eigener Branch wegen Risk)
- M-22 Pagination-Patterns vereinheitlichen (Frontend-Impact)
- L-32 `_OrmProxy` Dokumentations-Kommentar entfernen (cosmetic)
- L-35 chat created_at sub-microsecond ordering
- TLS via Caddy (eigene Migration)
- Vision-LLM-OCR (Qwen 2.5-VL als Tesseract-Alternative)
- Tailwind v3 -> v4
- Vite 6 -> 7+ (Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)